### PR TITLE
Fix to check clickRef

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@ const useDoubleClick = ({
 }) => {
   useEffect(() => {
     const clickRef = ref.current;
+    if (!clickRef) return;
     let clickCount = 0;
     const handleClick = e => {
       clickCount += 1;
@@ -35,7 +36,7 @@ const useDoubleClick = ({
     return () => {
       clickRef.removeEventListener('click', handleClick);
     };
-  });
+  }, [ref, latency, onSingleClick, onDoubleClick]);
 };
 
 export default useDoubleClick;


### PR DESCRIPTION
Thanks for creating a great library!

When I was using this library, I noticed that when I call Storyshots, I get the error `"TypeError: Cannot read property 'addEventListener' of null"`.

So I added a process to check for the existence of "ref.current". Please check it.